### PR TITLE
Initial CI/CD support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,44 +19,14 @@ jobs:
         distribution: 'liberica'
         cache: maven
 
-    - name: Generate GPG key
-      run: |
-        cat >gen-key-script <<EOF
-        %no-protection
-        %echo Generating a temporary GPG key
-        Key-Type: 1
-        Key-Length: 2048
-        Subkey-Type: 1
-        Subkey-Length: 2048
-        Name-Real: Temporary CI Key
-        Name-Comment: Signing key for CI builds
-        Name-Email: ci@example.com
-        Expire-Date: 1d
-        %commit
-        %echo done
-        EOF
-        gpg --batch --generate-key gen-key-script
-        gpg --list-secret-keys --keyid-format LONG
-        GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep 'sec' | awk '{print $2}' | awk -F'/' '{print $2}')
-        echo "GPG_KEY_ID=$GPG_KEY_ID" >> $GITHUB_ENV
-
-    - name: Import GPG key to Maven settings
-      run: |
-        mkdir -p ~/.gnupg
-        chmod 700 ~/.gnupg
-        echo "use-agent" > ~/.gnupg/gpg.conf
-        echo "GPG_TTY=$(tty)" >> ~/.bashrc
-        gpg --list-keys
-        echo '<settings><servers><server><id>gpg.passphrase</id><passphrase>'"$GPG_KEY_ID"'</passphrase></server></servers></settings>' > ~/.m2/settings.xml
-
     - name: Build embedCONTROLCore
-      run: mvn -B install --file embedCONTROLCore/pom.xml
+      run: mvn -B install -Dgpg.skip=true --file embedCONTROLCore/pom.xml
 
     - name: Build tcMenuJavaApi
-      run: mvn -B install --file tcMenuJavaApi/pom.xml
+      run: mvn -B install -Dgpg.skip=true --file tcMenuJavaApi/pom.xml
 
     - name: Build tcMenuGenerator
-      run: mvn -B install --file tcMenuGenerator/pom.xml
+      run: mvn -B compile -Dgpg.skip=true --file tcMenuGenerator/pom.xml
 
     - name: Build embeddedJavaExample
       run: mvn -B package --file embeddedJavaExample/pom.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 22
+      uses: actions/setup-java@v4
+      with:
+        java-version: '22'
+        distribution: 'liberica'
+        cache: maven
+
+    - name: Generate GPG key
+      run: |
+        cat >gen-key-script <<EOF
+        %no-protection
+        %echo Generating a temporary GPG key
+        Key-Type: 1
+        Key-Length: 2048
+        Subkey-Type: 1
+        Subkey-Length: 2048
+        Name-Real: Temporary CI Key
+        Name-Comment: Signing key for CI builds
+        Name-Email: ci@example.com
+        Expire-Date: 1d
+        %commit
+        %echo done
+        EOF
+        gpg --batch --generate-key gen-key-script
+        gpg --list-secret-keys --keyid-format LONG
+        GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep 'sec' | awk '{print $2}' | awk -F'/' '{print $2}')
+        echo "GPG_KEY_ID=$GPG_KEY_ID" >> $GITHUB_ENV
+
+    - name: Import GPG key to Maven settings
+      run: |
+        mkdir -p ~/.gnupg
+        chmod 700 ~/.gnupg
+        echo "use-agent" > ~/.gnupg/gpg.conf
+        echo "GPG_TTY=$(tty)" >> ~/.bashrc
+        gpg --list-keys
+        echo '<settings><servers><server><id>gpg.passphrase</id><passphrase>'"$GPG_KEY_ID"'</passphrase></server></servers></settings>' > ~/.m2/settings.xml
+
+    - name: Build embedCONTROLCore
+      run: mvn -B install --file embedCONTROLCore/pom.xml
+
+    - name: Build tcMenuJavaApi
+      run: mvn -B install --file tcMenuJavaApi/pom.xml
+
+    - name: Build tcMenuGenerator
+      run: mvn -B install --file tcMenuGenerator/pom.xml
+
+    - name: Build embeddedJavaExample
+      run: mvn -B package --file embeddedJavaExample/pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
 builtPlugins
+.idea/
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -28,5 +28,5 @@
       </set>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" project-jdk-name="temurin-22" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" project-jdk-name="22" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="SqlDialectMappings">
-    <file url="file://$PROJECT_DIR$/embedCONTROLCore/src/main/java/com/thecoderscorner/embedcontrol/core/service/DatabaseAppDataStore.java" dialect="SQLite" />
-    <file url="file://$PROJECT_DIR$/embedCONTROLCore/src/main/java/com/thecoderscorner/embedcontrol/core/util/TccDatabaseUtilities.java" dialect="GenericSQL" />
-    <file url="file://$PROJECT_DIR$/tcMenuGenerator/src/main/java/com/thecoderscorner/menu/editorui/storage/JdbcTcMenuConfigurationStore.java" dialect="SQLite" />
-  </component>
-</project>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 ## tcMenu - A menu library and designer for Arduino and mbed with IoT capabilities
+[![Java Build](https://github.com/TcMenu/tcMenu/actions/workflows/build.yml/badge.svg)](https://github.com/TcMenu/tcMenu/actions/workflows/build.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache--2.0-green.svg)](https://github.com/TcMenu/tcMenu/blob/main/LICENSE)
+[![GitHub release](https://img.shields.io/github/release/TcMenu/tcMenu.svg?maxAge=3600)](https://github.com/TcMenu/tcMenu/releases)
+[![davetcc](https://img.shields.io/badge/davetcc-dev-blue.svg)](https://github.com/davetcc)
+[![JSC TechMinds](https://img.shields.io/badge/JSC-TechMinds-green.svg)](https://www.jsctm.cz)
 
 A menu library and designer UI for Arduino and mbed that is modular enough to support different input methods, display modules and IoT / remote control methods. TcMenu is more than just an Arduino menu library, think of it as a framework for building IoT applications that includes the ability to render menus locally onto a display.
 

--- a/embedCONTROLCore/pom.xml
+++ b/embedCONTROLCore/pom.xml
@@ -50,15 +50,12 @@
     </scm>
 
     <properties>
-        <jdk.version>21</jdk.version>
-        <jfx.version>21.0.2</jfx.version>
-        <jserialcomm.version>2.10.4</jserialcomm.version>
-        <google.gson.version>2.10</google.gson.version>
-        <springframework.version>6.0.11</springframework.version>
-        <junit5.surefire.version>1.3.2</junit5.surefire.version>
-        <junit5.version>5.10.2</junit5.version>
-        <mockito.version>5.10.0</mockito.version>
-        <hamcrest.version>2.2</hamcrest.version>
+        <jdk.version>22</jdk.version>
+        <jfx.version>22.0.2</jfx.version>
+        <jserialcomm.version>2.11.0</jserialcomm.version>
+        <google.gson.version>2.11.0</google.gson.version>
+        <junit5.version>5.11.0</junit5.version>
+        <mockito.version>5.12.0</mockito.version>
     </properties>
 
     <dependencies>
@@ -82,13 +79,13 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.7.2</version>
+            <version>2.7.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.12</version>
+            <version>2.0.16</version>
         </dependency>
 
         <dependency>
@@ -105,12 +102,6 @@
         <!-- END JavaFX notes -->
 
         <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>${junit5.surefire.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit5.version}</version>
@@ -125,7 +116,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.25.2</version>
+            <version>3.26.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -136,7 +127,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>${jdk.version}</source>
                     <target>${jdk.version}</target>
@@ -145,12 +136,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -163,7 +154,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.8.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -176,7 +167,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.5</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -190,7 +181,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <version>1.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -201,7 +192,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.1.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <useReleaseProfile>false</useReleaseProfile>

--- a/embeddedJavaExample/pom.xml
+++ b/embeddedJavaExample/pom.xml
@@ -7,9 +7,9 @@
     <version>0.0.1-SNAPSHOT</version>
 
     <properties>
-        <jdk.version>20</jdk.version>
-        <jfx.version>21.0.2</jfx.version>
-        <jserialcomm.version>2.9.2</jserialcomm.version>
+        <jdk.version>22</jdk.version>
+        <jfx.version>22.0.2</jfx.version>
+        <jserialcomm.version>2.11.0</jserialcomm.version>
         <tcmenu.api.version>4.3.0</tcmenu.api.version>
         <timestamp>${maven.build.timestamp}</timestamp>
     </properties>
@@ -33,7 +33,7 @@
 
         <!--
         !!!!!!!JavaFX - Special notes!!!!!!
-        If you are using BellSoft's Liberica Full JDK leave the below scopes set to "test"
+        If you are using BellSoft Liberica Full JDK leave the below scopes set to "test"
         If you are using another JDK without JavaFX, comment out the scope for each org.openjfx component.
          -->
 
@@ -53,19 +53,19 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>10.0.14</version>
+            <version>10.0.23</version>
         </dependency>
 
         <!-- To run javax.websocket in embedded server -->
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-javax-server</artifactId>
-            <version>10.0.14</version>
+            <version>10.0.23</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.36</version>
+            <version>2.0.16</version>
         </dependency>
 
     </dependencies>
@@ -92,7 +92,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>${jdk.version}</source>
                     <target>${jdk.version}</target>
@@ -102,7 +102,7 @@
                 <!-- copy all the JARs for the dependencies into the jfx/deps folder -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.8.0</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -137,7 +137,7 @@
                 <!-- copy the application JAR file from target dir into jfx/deps -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>copy-resources-jar</id>
@@ -163,7 +163,7 @@
             <plugin>
                 <!-- copy the data folder into the jfx/app folder -->
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>copy-resources-logging</id>

--- a/embeddedJavaExample/src/main/java/com/thecoderscorner/menuexample/tcmenu/EmbeddedJavaDemoApp.java
+++ b/embeddedJavaExample/src/main/java/com/thecoderscorner/menuexample/tcmenu/EmbeddedJavaDemoApp.java
@@ -48,7 +48,7 @@ public class EmbeddedJavaDemoApp {
         MenuCommandProtocol protocol = context.getBean(MenuCommandProtocol.class);
         ScheduledExecutorService executor = context.getBean(ScheduledExecutorService.class);
         LocalIdentifier localId = new LocalIdentifier(menuManager.getServerUuid(), menuManager.getServerName());
-        var remMenuAvrBoardConnector = new SocketBasedConnector(localId, executor, Clock.systemUTC(), protocol, "192.168.0.96", 3333, ConnectMode.FULLY_AUTHENTICATED);
+        var remMenuAvrBoardConnector = new SocketBasedConnector(localId, executor, Clock.systemUTC(), protocol, "192.168.0.96", 3333, ConnectMode.FULLY_AUTHENTICATED, null);
         var remMenuAvrBoard = new MenuInMenu(remMenuAvrBoardConnector, menuManager, menuManager.getManagedMenu().getMenuById(16).orElseThrow(), MenuInMenu.ReplicationMode.REPLICATE_ADD_STATUS_ITEM, 100000, 65000);
         remMenuAvrBoard.start();
     }

--- a/tcMenuGenerator/pom.xml
+++ b/tcMenuGenerator/pom.xml
@@ -19,17 +19,15 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
 
         <!-- production deps -->
-        <jfx.version>21.0.2</jfx.version>
+        <jdk.version>22</jdk.version>
+        <jfx.version>22.0.2</jfx.version>
         <jmetro.version>11.6.16</jmetro.version>
-        <google.gson.version>2.10</google.gson.version>
-        <picocli.version>4.7.5</picocli.version>
-        <springframework.version>6.0.11</springframework.version>
+        <google.gson.version>2.11.0</google.gson.version>
+        <picocli.version>4.7.6</picocli.version>
 
         <!-- test deps -->
-        <junit5.surefire.version>1.3.2</junit5.surefire.version>
-        <junit5.version>5.10.2</junit5.version>
-        <mockito.version>5.10.0</mockito.version>
-        <hamcrest.version>2.2</hamcrest.version>
+        <junit5.version>5.11.0</junit5.version>
+        <mockito.version>5.12.0</mockito.version>
         <testfx.version>4.0.18</testfx.version>
     </properties>
 
@@ -62,7 +60,7 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <version>2.7.2</version>
+            <version>2.7.3</version>
         </dependency>
 
         <dependency>
@@ -117,12 +115,6 @@
         <!-- test only dependencies start -->
 
         <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>${junit5.surefire.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit5.version}</version>
@@ -170,20 +162,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>22</source>
-                    <target>22</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                     <compilerArgs>--enable-preview</compilerArgs>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M3</version>
-                <configuration>
-                    <excludes>com/thecoderscorner/menu/editorint/**</excludes>
-                </configuration>
+                <version>3.4.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -220,7 +209,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>copy-resources-logging</id>
@@ -296,7 +285,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.7.1</version>
                 <executions>
                     <execution>
                         <phase>compile</phase> <!-- bind to the packaging phase -->

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorint/uitests/AboutDialogTestCases.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorint/uitests/AboutDialogTestCases.java
@@ -6,24 +6,17 @@
 
 package com.thecoderscorner.menu.editorint.uitests;
 
-import com.thecoderscorner.menu.editorui.generator.core.CreatorProperty;
-import com.thecoderscorner.menu.editorui.storage.ConfigurationStorage;
 import com.thecoderscorner.menu.editorui.dialog.AboutDialog;
+import com.thecoderscorner.menu.editorui.storage.ConfigurationStorage;
 import javafx.application.Platform;
-import javafx.scene.Node;
-import javafx.scene.control.RadioButton;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.testfx.api.FxAssert;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
-import org.testfx.matcher.control.TextInputControlMatchers;
 
-import static com.thecoderscorner.menu.editorui.generator.parameters.FontDefinition.fromString;
-import static com.thecoderscorner.menu.editorui.util.TestUtils.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testfx.api.FxAssert.verifyThat;

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorint/uitests/EditEEPROMTestCase.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorint/uitests/EditEEPROMTestCase.java
@@ -4,7 +4,6 @@ import com.thecoderscorner.menu.editorui.dialog.SelectEepromTypeDialog;
 import com.thecoderscorner.menu.editorui.generator.parameters.eeprom.*;
 import com.thecoderscorner.menu.editorui.util.TestUtils;
 import javafx.scene.Node;
-import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.RadioButton;
 import javafx.stage.Stage;
@@ -13,7 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.testfx.api.FxRobot;
 import org.testfx.framework.junit5.ApplicationExtension;
 import org.testfx.framework.junit5.Start;
-import org.testfx.matcher.control.LabeledMatchers;
 import org.testfx.matcher.control.TextInputControlMatchers;
 import org.testfx.util.WaitForAsyncUtils;
 

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorint/uitests/IoExpanderDialogTestCases.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorint/uitests/IoExpanderDialogTestCases.java
@@ -5,7 +5,6 @@ import com.thecoderscorner.menu.editorui.dialog.ChooseIoExpanderDialog;
 import com.thecoderscorner.menu.editorui.generator.parameters.IoExpanderDefinition;
 import com.thecoderscorner.menu.editorui.generator.parameters.expander.*;
 import com.thecoderscorner.menu.editorui.project.CurrentEditorProject;
-import com.thecoderscorner.menu.editorui.uimodel.CurrentProjectEditorUI;
 import com.thecoderscorner.menu.editorui.uimodel.CurrentProjectEditorUIImpl;
 import com.thecoderscorner.menu.editorui.util.TestUtils;
 import javafx.application.Platform;

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/cli/CoreCommandTests.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/cli/CoreCommandTests.java
@@ -8,7 +8,6 @@ import picocli.CommandLine;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CoreCommandTests {

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/arduino/ArduinoSketchFileAdjusterTest.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/arduino/ArduinoSketchFileAdjusterTest.java
@@ -13,7 +13,6 @@ import com.thecoderscorner.menu.domain.state.MenuTree;
 import com.thecoderscorner.menu.editorui.generator.CodeGeneratorOptions;
 import com.thecoderscorner.menu.editorui.generator.core.VariableNameGenerator;
 import com.thecoderscorner.menu.editorui.storage.ConfigurationStorage;
-import com.thecoderscorner.menu.editorui.storage.PrefsConfigurationStorage;
 import com.thecoderscorner.menu.editorui.util.TestUtils;
 import com.thecoderscorner.menu.persist.LocaleMappingHandler;
 import org.junit.jupiter.api.AfterEach;
@@ -31,7 +30,6 @@ import java.util.function.BiConsumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/core/CodeVariableCppExtractorTest.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/core/CodeVariableCppExtractorTest.java
@@ -9,7 +9,6 @@ package com.thecoderscorner.menu.editorui.generator.core;
 
 import com.thecoderscorner.menu.editorui.generator.CodeGeneratorOptions;
 import com.thecoderscorner.menu.editorui.generator.applicability.AlwaysApplicable;
-import com.thecoderscorner.menu.editorui.generator.arduino.ArduinoGenerator;
 import com.thecoderscorner.menu.editorui.generator.plugin.EmbeddedPlatform;
 import com.thecoderscorner.menu.editorui.util.TestUtils;
 import org.assertj.core.api.Assertions;
@@ -20,7 +19,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.thecoderscorner.menu.domain.state.MenuTree.ROOT;
-import static com.thecoderscorner.menu.editorui.generator.core.HeaderDefinition.HeaderType.*;
+import static com.thecoderscorner.menu.editorui.generator.core.HeaderDefinition.HeaderType.GLOBAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/parameters/AuthenticatorDefinitionTest.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/parameters/AuthenticatorDefinitionTest.java
@@ -8,8 +8,8 @@ import com.thecoderscorner.menu.editorui.generator.parameters.auth.ReadOnlyAuthe
 import org.junit.jupiter.api.Test;
 
 import static com.thecoderscorner.menu.editorui.generator.core.CoreCodeGenerator.LINE_BREAK;
-import static com.thecoderscorner.menu.editorui.generator.core.HeaderDefinition.*;
-import static com.thecoderscorner.menu.editorui.generator.core.HeaderDefinition.HeaderType.*;
+import static com.thecoderscorner.menu.editorui.generator.core.HeaderDefinition.HeaderType.GLOBAL;
+import static com.thecoderscorner.menu.editorui.generator.core.HeaderDefinition.PRIORITY_NORMAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/parameters/EepromDefinitionTest.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/parameters/EepromDefinitionTest.java
@@ -9,7 +9,7 @@ import static com.thecoderscorner.menu.editorui.generator.core.CoreCodeGenerator
 import static com.thecoderscorner.menu.editorui.generator.core.HeaderDefinition.HeaderType.GLOBAL;
 import static com.thecoderscorner.menu.editorui.generator.core.HeaderDefinition.PRIORITY_NORMAL;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class EepromDefinitionTest {
     @Test

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/parameters/FontDefinitionTest.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/parameters/FontDefinitionTest.java
@@ -2,8 +2,9 @@ package com.thecoderscorner.menu.editorui.generator.parameters;
 
 import org.junit.jupiter.api.Test;
 
-import static com.thecoderscorner.menu.editorui.generator.parameters.FontDefinition.FontMode.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static com.thecoderscorner.menu.editorui.generator.parameters.FontDefinition.FontMode.ADAFRUIT;
+import static com.thecoderscorner.menu.editorui.generator.parameters.FontDefinition.FontMode.ADAFRUIT_LOCAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class FontDefinitionTest {
     @Test

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/parameters/MenuInMenuCollectionTest.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/parameters/MenuInMenuCollectionTest.java
@@ -3,9 +3,10 @@ package com.thecoderscorner.menu.editorui.generator.parameters;
 import com.thecoderscorner.menu.mgr.MenuInMenu;
 import org.junit.jupiter.api.Test;
 
-import static com.thecoderscorner.menu.editorui.generator.parameters.MenuInMenuDefinition.*;
+import static com.thecoderscorner.menu.editorui.generator.parameters.MenuInMenuDefinition.ConnectionType;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class MenuInMenuCollectionTest {
     @Test

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/plugin/DefaultXmlPluginLoaderTest.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/plugin/DefaultXmlPluginLoaderTest.java
@@ -1,6 +1,5 @@
 package com.thecoderscorner.menu.editorui.generator.plugin;
 
-import com.thecoderscorner.menu.editorui.storage.ConfigurationStorage;
 import com.thecoderscorner.menu.editorui.generator.applicability.AlwaysApplicable;
 import com.thecoderscorner.menu.editorui.generator.applicability.EqualityApplicability;
 import com.thecoderscorner.menu.editorui.generator.applicability.MatchesApplicability;
@@ -11,6 +10,7 @@ import com.thecoderscorner.menu.editorui.generator.core.SubSystem;
 import com.thecoderscorner.menu.editorui.generator.parameters.FontCodeParameter;
 import com.thecoderscorner.menu.editorui.generator.parameters.LambdaCodeParameter;
 import com.thecoderscorner.menu.editorui.generator.validation.*;
+import com.thecoderscorner.menu.editorui.storage.ConfigurationStorage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/validation/CannedPropertyValidatorsTest.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/generator/validation/CannedPropertyValidatorsTest.java
@@ -6,7 +6,6 @@
 
 package com.thecoderscorner.menu.editorui.generator.validation;
 
-import com.thecoderscorner.menu.editorui.generator.CodeGeneratorOptions;
 import com.thecoderscorner.menu.editorui.generator.CodeGeneratorOptionsBuilder;
 import com.thecoderscorner.menu.editorui.generator.parameters.FontDefinition;
 import com.thecoderscorner.menu.editorui.generator.parameters.IoExpanderDefinitionCollection;
@@ -18,7 +17,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.thecoderscorner.menu.editorui.generator.parameters.FontDefinition.*;
+import static com.thecoderscorner.menu.editorui.generator.parameters.FontDefinition.FontMode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;

--- a/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/gfxui/pixmgr/UIColorPaletteControlTest.java
+++ b/tcMenuGenerator/src/test/java/com/thecoderscorner/menu/editorui/gfxui/pixmgr/UIColorPaletteControlTest.java
@@ -1,5 +1,0 @@
-package com.thecoderscorner.menu.editorui.gfxui.pixmgr;
-
-class UIColorPaletteControlTest {
-
-}

--- a/tcMenuJavaApi/pom.xml
+++ b/tcMenuJavaApi/pom.xml
@@ -49,19 +49,18 @@
     </distributionManagement>
 
     <properties>
-        <jdk.version>11</jdk.version>
-        <jfx.version>11</jfx.version>
-        <junit5.surefire.version>1.3.2</junit5.surefire.version>
-        <junit5.version>5.9.0</junit5.version>
-        <mockito.version>4.8.0</mockito.version>
-        <hamcrest.version>2.2</hamcrest.version>
+        <jdk.version>22</jdk.version>
+        <jfx.version>22.0.2</jfx.version>
+        <junit5.version>5.11.0</junit5.version>
+        <mockito.version>5.12.0</mockito.version>
+        <hamcrest.version>3.0</hamcrest.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.0</version>
+            <version>2.11.0</version>
         </dependency>
 
         <!-- test dependencies -->
@@ -69,19 +68,13 @@
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
-            <version>1.5.3</version>
+            <version>1.5.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>${junit5.surefire.version}</version>
+            <version>2.0.16</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -111,7 +104,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.23.1</version>
+            <version>3.26.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -137,12 +130,12 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.17.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>${jdk.version}</source>
                     <target>${jdk.version}</target>
@@ -151,12 +144,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.4</version>
+                <version>3.4.0</version>
             </plugin>
         <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -169,7 +162,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.8.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -182,7 +175,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.5</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -196,7 +189,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <version>1.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -207,7 +200,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.1.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <useReleaseProfile>false</useReleaseProfile>

--- a/tcMenuJavaApi/src/main/java/com/thecoderscorner/menu/remote/protocol/TagValMenuCommandProcessors.java
+++ b/tcMenuJavaApi/src/main/java/com/thecoderscorner/menu/remote/protocol/TagValMenuCommandProcessors.java
@@ -19,10 +19,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -538,7 +535,7 @@ public class TagValMenuCommandProcessors {
         appendField(sb, KEY_FLOAT_DECIMAL_PLACES, decimalPlaces);
         appendField(sb, KEY_NEGATIVE_ALLOWED, isNegativeAllowed ? 1 : 0);
         appendField(sb, KEY_MAX_LENGTH, cmd.getMenuItem().getDigitsAllowed());
-        NumberFormat fmt = NumberFormat.getInstance();
+        NumberFormat fmt = NumberFormat.getInstance(Locale.US);
         fmt.setGroupingUsed(false);
         fmt.setMinimumFractionDigits(decimalPlaces);
         fmt.setMaximumFractionDigits(decimalPlaces);

--- a/xmlPlugins/xmlPlugins.iml
+++ b/xmlPlugins/xmlPlugins.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_22" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />


### PR DESCRIPTION
This is the first of the series of PRs to add support for the CI/CD.

# Summary
- All Java modules are automatically compiled
- Unit tests are run for embedCONTROLCore and tcMenuJavaApi
- tcMenuGenerator has testing feature disabled at the moment as the tests are more complex
- Dependencies in pom files were updated, mostly to the latest versions but the embeddedJavaExample required older jetty webserver
- Fixed Java API when run on non-english environment